### PR TITLE
Fixed issue with message line breaks not appearing

### DIFF
--- a/src/Admin.js
+++ b/src/Admin.js
@@ -97,14 +97,16 @@ class Admin extends Component {
             </li>
           </ul>
           <div className="w3-container">
-            <Message
-              message={ this.state.message }
-              nextMessage={ this.state.nextMessage }
-              onSave={ this.handleSaveMessage }
-              showModal={ this.state.showModalMessage }
-              onClose={ () => this.setState({ showModalMessage: false }) }
-              onChange={ (val) => this.setState({ nextMessage: val })}
-            />
+            <pre id="notes_text">
+              <Message
+                message={ this.state.message }
+                nextMessage={ this.state.nextMessage }
+                onSave={ this.handleSaveMessage }
+                showModal={ this.state.showModalMessage }
+                onClose={ () => this.setState({ showModalMessage: false }) }
+                onChange={ (val) => this.setState({ nextMessage: val })}
+              />
+            </pre>
           </div>
           <ul className="w3-navbar w3-light-grey w3-xlarge">
             <li className="w3-navitem">Services</li>

--- a/src/App.css
+++ b/src/App.css
@@ -40,12 +40,23 @@ table#status_table {
 #notes_div {
   padding: 5px;
   overflow: hidden;
-  height: 150px;
+  height: 155px;
   border:solid 1px black;
   color: black;
   word-wrap: break-word;
   margin: 0;
   font-size: 12px;
+}
+
+#notes_text {
+  font-family: "nta", Arial, sans-serif;
+  font-size: 14px;
+  white-space: pre-wrap;       /* Since CSS 2.1 */
+  white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
+  white-space: -pre-wrap;      /* Opera 4-6 */
+  white-space: -o-pre-wrap;    /* Opera 7 */
+  word-wrap: break-word;       /* Internet Explorer 5.5+ */
+  margin:0;
 }
 
 #notes_heading {

--- a/src/App.js
+++ b/src/App.js
@@ -70,7 +70,7 @@ class App extends Component {
           <tr>
             <td id="notes_cell" colSpan={ 2 }>
               <div id="notes_div">
-                { this.state.message }
+                <pre id="notes_text">{ this.state.message }</pre>
               </div>
             </td>
           </tr>


### PR DESCRIPTION
Messages that were on multiple lines were being displayed as if they were all on one line.  Added pre tags and styling to fix.